### PR TITLE
[CHORE] - Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/streamdeck-rs.svg)](https://crates.io/crates/streamdeck-rs) ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg) [![Build Status](https://github.com/mdonoughe/streamdeck-rs/actions/workflows/check.yml/badge.svg)](https://github.com/mdonoughe/streamdeck-rs/actions/workflows/check.yml) [![Docs.rs](https://docs.rs/streamdeck-rs/badge.svg)](https://docs.rs/streamdeck-rs)
 
-Elgato's official [Stream Deck SDK](https://developer.elgato.com/documentation/stream-deck/sdk/overview/) works by launching plugins in their own processes and communicating via web sockets. This library provides the command line argument parsing and basic protocol details for creating a plugin using Rust.
+Elgato's official [Stream Deck SDK](https://docs.elgato.com/sdk/plugins/overview) works by launching plugins in their own processes and communicating via web sockets. This library provides the command line argument parsing and basic protocol details for creating a plugin using Rust.
 
 This library is pretty basic for now. In the future it could provide a framework for instancing actions (keys) and routing messages to the appropriate instances.
 
@@ -12,4 +12,4 @@ This library is pretty basic for now. In the future it could provide a framework
 
 1. Create a binary executable project.
 2. Use `RegistrationParams` to get the information required to use `StreamDeckSocket`.
-3. See [the official documentation](https://developer.elgato.com/documentation/stream-deck/sdk/overview/) for information about [creating manifests](https://developer.elgato.com/documentation/stream-deck/sdk/manifest/) and [loading your plugin](https://developer.elgato.com/documentation/stream-deck/sdk/create-your-own-plugin/).
+3. See [the official documentation](https://docs.elgato.com/sdk/plugins/overview) for information about [creating manifests](https://docs.elgato.com/sdk/plugins/manifest) and [loading your plugin](https://docs.elgato.com/sdk/plugins/getting-started).


### PR DESCRIPTION
## Problem

[Reported Issue](https://github.com/mdonoughe/streamdeck-rs/issues/11)

## Solution

Use URLs that resolve to the expected pages on the Elgato documentation site.

